### PR TITLE
update to 0.1.29

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "orange-canvas-core" %}
-{% set version = "0.1.27" %}
-{% set sha256 = "c8ffece2e1c5922bec11a02c111296c0690ba5a48c9c4c2c827ecaa9e603995f" %}
+{% set version = "0.1.28" %}
+{% set sha256 = "ff7f53eb2410ff809176ab2eee925efa711003b02d98074d1167aba12abdf642" %}
 
 # on our linux builders there is no X11 installed and therefore import
 # test will fail
@@ -21,20 +21,18 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv
+  # NOTE-TO-SELF: maybe I don't need to skip these anymore
   skip: True  # [py<37]
   skip: True  # [linux and (s390x or ppc64le)]
 
 requirements:
   host:
-    - python
+    - python >=3.6
     - pip
-    - setuptools
-    - wheel
   run:
-    - python
+    - python >=3.6
     - pip    >=18.0
     - setuptools
-    - wheel
     - anyqt >=0.1.0
     - pyqt
     - docutils

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  skip: True  # [py<38]
+  skip: True  # [py<36]
   skip: True  # [linux and (s390x or ppc64le)]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,10 +28,10 @@ requirements:
   host:
     - python
     - pip
+    - setuptools
   run:
     - python
     - pip >=18.0
-    - setuptools
     - anyqt >=0.1.0
     - pyqt
     - docutils

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,8 +21,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv
-  # NOTE-TO-SELF: maybe I don't need to skip these anymore
-  skip: True  # [py<37]
+  skip: True  # [py<38]
   skip: True  # [linux and (s390x or ppc64le)]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,6 +52,7 @@ test:
   commands:
     - pip check
   requires:
+    - python
     - pip
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,7 @@ requirements:
     - python
     - pip
     - setuptools
+    - wheel
   run:
     - python
     - pip >=18.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,11 +44,9 @@ requirements:
     - qasync
 
 test:
-{% if enable_testingui %}
   imports:
     - orangecanvas.main
     - orangecanvas.application.canvasmain
-{% endif %}
   commands:
     - pip check
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,36 +20,39 @@ source:
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   skip: True  # [py<38]
   skip: True  # [linux and (s390x or ppc64le)]
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
   run:
-    - python >=3.6
-    - pip    >=18.0
+    - python
+    - pip >=18.0
     - setuptools
     - anyqt >=0.1.0
     - pyqt
     - docutils
     - commonmark >=0.8.1
     - requests
-    - cachecontrol >=0.12.6
+    - cachecontrol-with-filecache >=0.12.6
     # via cachecontrol[filecache]
     - lockfile >=0.9
     - dictdiffer
     - qasync
-    - importlib_metadata
 
-{% if enable_testingui %}
 test:
+{% if enable_testingui %}
   imports:
     - orangecanvas.main
     - orangecanvas.application.canvasmain
 {% endif %}
+  commands:
+    - pip check
+  requires:
+    - pip
 
 about:
   home: https://github.com/biolab/orange-canvas-core

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,6 @@ requirements:
     - requests
     - cachecontrol-with-filecache >=0.12.6
     # via cachecontrol[filecache]
-    - lockfile >=0.9
     - dictdiffer
     - qasync
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "orange-canvas-core" %}
-{% set version = "0.1.28" %}
-{% set sha256 = "ff7f53eb2410ff809176ab2eee925efa711003b02d98074d1167aba12abdf642" %}
+{% set version = "0.1.29" %}
+{% set sha256 = "2541f14ca598f051a0bea0663bc9bcb61ac1790dc2b50292367728f5948a5e7f" %}
 
 # on our linux builders there is no X11 installed and therefore import
 # test will fail


### PR DESCRIPTION
* Orange3 -> orange-canvas-core-feedstock (PKG-1208)
* Enables Orange3 to be updated to =>3.34.0
* Sources from [pypi](https://files.pythonhosted.org/packages/38/a3/bba36d297ede9f45143d05d1745742185ce3516a36e19d0057b35f8cdf73/orange-canvas-core-0.1.29.tar.gz) were checked: setup.py and PKG-INFO
* Updated list of dependencies, build steps and sha
* Update to 0.1.29 was favoured over 0.1.30 because the latter would imply updating anyqt which can be very burdensome