### PR TITLE
Update orange-canvas-core to 0.1.35

### DIFF
--- a/recipe/abs.yaml
+++ b/recipe/abs.yaml
@@ -1,0 +1,3 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/url-normalize-feedstock/pr2/ca85677
+  - https://staging.continuum.io/prefect/fs/requests-cache-feedstock/pr2/7b8c1e1

--- a/recipe/abs.yaml
+++ b/recipe/abs.yaml
@@ -1,3 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/url-normalize-feedstock/pr2/ca85677
-  - https://staging.continuum.io/prefect/fs/requests-cache-feedstock/pr2/7b8c1e1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,15 +33,15 @@ requirements:
   run:
     - python
     - pip >=18.0
-    - anyqt >=0.1.0
-    - pyqt
+    - anyqt >=0.2.0
     - docutils
     - commonmark >=0.8.1
     - requests
-    - cachecontrol-with-filecache >=0.12.6
-    # via cachecontrol[filecache]
+    - requests-cache
     - dictdiffer
-    - qasync
+    - qasync >=0.10.0
+    - packaging
+    - {{ pin_compatible('numpy') }}
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "orange-canvas-core" %}
-{% set version = "0.1.29" %}
-{% set sha256 = "2541f14ca598f051a0bea0663bc9bcb61ac1790dc2b50292367728f5948a5e7f" %}
+{% set version = "0.1.35" %}
+{% set sha256 = "c4b0b08de343c7d46ac65364216328d0f72b83b6a41aebb846ff6844380e2b5f" %}
 
 # on our linux builders there is no X11 installed and therefore import
 # test will fail

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,6 @@ test:
   commands:
     - pip check
   requires:
-    - python
     - pip
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ requirements:
     - dictdiffer
     - qasync >=0.10.0
     - packaging
-    - {{ pin_compatible('numpy') }}
+    - numpy
 
 test:
   imports:


### PR DESCRIPTION
orange-canvas-core 0.1.35

**Destination channel:** {defaults}

### Links

- [PKG-4280](https://anaconda.atlassian.net/browse/PKG-4280) 
- [Upstream repository](https://github.com/biolab/orange-canvas-core/blob/0.1.35)
- Relevant dependency PRs:
  - `url-normalize` > `requests-cache` > `orange-canvas-core` > `orange-widget-base` > `orange3`

### Explanation of changes:
- Updated `version` and `hash`
- Updated dependencies
- Added abs.yaml to be removed PRIOR to merge

[PKG-4280]: https://anaconda.atlassian.net/browse/PKG-4280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ