### PR TITLE
orange-canvas-core 0.2.5

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,6 +42,8 @@ requirements:
     - qasync >=0.10.0
     - packaging
     - numpy
+    - importlib_metadata >=4.6  # [py<310]
+    - importlib_resources  # [py<39]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "orange-canvas-core" %}
-{% set version = "0.1.35" %}
-{% set sha256 = "c4b0b08de343c7d46ac65364216328d0f72b83b6a41aebb846ff6844380e2b5f" %}
+{% set version = "0.2.5" %}
 
 # on our linux builders there is no X11 installed and therefore import
 # test will fail
@@ -15,13 +14,13 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  url: https://github.com/biolab/{{ name }}/archive/refs/tags/0.2.5.tar.gz
+  sha256: 302768229eab2497bc900d7dcbedd913b6d6fa6c1d336593dbe3e19abc49cf53
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  skip: True  # [py<36]
+  skip: True  # [py<38]
   skip: True  # [linux and (s390x or ppc64le)]
 
 requirements:
@@ -30,6 +29,7 @@ requirements:
     - pip
     - setuptools
     - wheel
+    - trubar >=0.3.3
   run:
     - python
     - pip >=18.0
@@ -45,8 +45,7 @@ requirements:
 
 test:
   imports:
-    - orangecanvas.main
-    - orangecanvas.application.canvasmain
+    - orangecanvas
   commands:
     - pip check
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,6 +43,7 @@ requirements:
     - numpy
     - importlib_metadata >=4.6  # [py<310]
     - importlib_resources  # [py<39]
+    - typing-extensions
 
 test:
   imports:
@@ -51,7 +52,6 @@ test:
     - pip check
   requires:
     - pip
-    - typing-extensions
 
 about:
   home: https://github.com/biolab/orange-canvas-core

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,8 +20,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  skip: True  # [py<38]
-  skip: True  # [linux and (s390x or ppc64le)]
+  skip: True  # [py<38 or s390x]
 
 requirements:
   host:
@@ -29,10 +28,9 @@ requirements:
     - pip
     - setuptools
     - wheel
-    - trubar >=0.3.3
+    - trubar
   run:
     - python
-    - pip >=18.0
     - anyqt >=0.2.0
     - docutils
     - commonmark >=0.8.1
@@ -60,14 +58,12 @@ about:
   license_family: GPL
   license_file: LICENSE.txt
   summary: Core component of Orange Canvas
-
   description: |
     Orange Canvas Core is is a framework for building graphical user
     interfaces for editing workflows. It is a component used to build
     the Orange Canvas (http://orange.biolab.si) data-mining application
     (for which it was developed in the first place).
-
-  doc_url: https://orange-canvas-core.readthedocs.io/
+  doc_url: https://github.com/biolab/orange-canvas-core/blob/master/README.rst
   dev_url: https://github.com/biolab/orange-canvas-core
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,6 +52,7 @@ test:
     - pip check
   requires:
     - pip
+    - typing-extensions
 
 about:
   home: https://github.com/biolab/orange-canvas-core

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,8 +28,9 @@ requirements:
     - pip
     - setuptools
     - wheel
-    - trubar
+    - trubar >=0.3.3
   run:
+    - pip >=18.0
     - python
     - anyqt >=0.2.0
     - docutils


### PR DESCRIPTION
> ## ☆ orange-canvas-core 0.2.5  ☆
> [Jira Ticket](https://anaconda.atlassian.net/browse/PKG-7233) 
[Upstream](https://github.com/biolab/orange-canvas-core/tree/0.2.5)
> 
> ### Changes
> * Updated version number and sha256
> * Updated dependencies for `run`, `host`, and `test` sections 
> * Added skip to python versions less than 3.8
> *  Updated `about` section 