### PR TITLE
orange-canvas-core 0.2.6 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/pbp/fs/commonmark-feedstock/pr1/f11dd56

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/pbp/fs/commonmark-feedstock/pr1/f11dd56

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  skip: True  # [py<38 or s390x]
+  skip: True  # [py<310]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -60,10 +60,9 @@ about:
   license_file: LICENSE.txt
   summary: Core component of Orange Canvas
   description: |
-    Orange Canvas Core is is a framework for building graphical user
-    interfaces for editing workflows. It is a component used to build
-    the Orange Canvas (http://orange.biolab.si) data-mining application
-    (for which it was developed in the first place).
+    Orange Canvas Core is is a framework for building graphical user interfaces
+    for editing workflows. It is a component used to build the Orange Canvas
+    data-mining application (for which it was developed in the first place).
   doc_url: https://github.com/biolab/orange-canvas-core/blob/master/README.rst
   dev_url: https://github.com/biolab/orange-canvas-core
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  skip: True  # [py<310]
+  skip: true  # [py<310]
 
 requirements:
   host:
@@ -41,9 +41,8 @@ requirements:
     - qasync >=0.10.0
     - packaging
     - numpy
-    - importlib_metadata >=4.6  # [py<310]
-    - importlib_resources  # [py<39]
     - typing-extensions
+    - truststore
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,6 +48,7 @@ test:
   imports:
     - orangecanvas
   commands:
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
     - pip check
   requires:
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "orange-canvas-core" %}
-{% set version = "0.2.5" %}
+{% set version = "0.2.6" %}
 
 # on our linux builders there is no X11 installed and therefore import
 # test will fail
@@ -14,8 +14,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/biolab/{{ name }}/archive/refs/tags/0.2.5.tar.gz
-  sha256: 302768229eab2497bc900d7dcbedd913b6d6fa6c1d336593dbe3e19abc49cf53
+  url: https://github.com/biolab/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
+  sha256: bb6626ed7e8bb65113041f92a00f50780d3ff88da0fb57a5c02dee3a0374bfd9
 
 build:
   number: 0


### PR DESCRIPTION
orange-canvas-core 0.2.6 

**Destination channel:** Defaults

### Links

- [PKG-11148]
- dev_url:        https://github.com/biolab/orange-canvas-core/tree/0.2.6
- conda_forge:    None
- pypi:           https://pypi.org/project/orange-canvas-core/0.2.6
- pypi inspector: https://inspector.pypi.io/project/orange-canvas-core/0.2.6

### Explanation of changes:

- new version number


[PKG-11148]: https://anaconda.atlassian.net/browse/PKG-11148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ